### PR TITLE
Add exit code for failed dbt run

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,5 @@ if [ $? -eq 0 ]
     echo "DBT_RUN_STATE=failed" >> $GITHUB_ENV
     echo "::set-output name=result::failed"
     echo "DBT run failed" >> "${DBT_LOG_FILE}"
+    exit 1
 fi


### PR DESCRIPTION
It's better to use proper exit code. If the run fails, you can still run subsequent steps with if: ${{ failure() }}﻿
