### PR TITLE
Don't exit if no bigquery token is provided.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,8 @@ set -o pipefail
 echo "dbt project folder set as: \"${INPUT_DBT_PROJECT_FOLDER}\""
 cd ${INPUT_DBT_PROJECT_FOLDER}
 
+echo trying to parse bigquery token
+
 if [ -n "${DBT_BIGQUERY_TOKEN}" ]
 then
   if $(echo ${DBT_BIGQUERY_TOKEN} | base64 -d > ./creds.json 2>/dev/null)
@@ -18,8 +20,7 @@ then
     exit 1
   fi
 else
-  echo cannot parse token
-  exit 1
+  echo no token provided
 fi
 
 if [ -n "${DBT_USER}" ] && [ -n "$DBT_PASSWORD" ]


### PR DESCRIPTION
Previously, the script would exit if no BigQuery token was provided. This made the script unusable for e.g. Snowflake users.