### PR TITLE
pin dbt-spark to the version specified by DBT_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ ARG DBT_VERSION=0.19.1
 FROM fishtownanalytics/dbt:${DBT_VERSION}
 RUN apt-get update && apt-get install libsasl2-dev
 
+# Need to re-declare the ARG to use its default value defined before the FROM
+ARG DBT_VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install dbt-spark dbt-spark[PyHive]
+    pip install dbt-spark[PyHive]==${DBT_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Partially resolves #11. This should now prevent this action from breaking when dbt releases a new version with breaking changes. 