### PR TITLE
Typo in config files / entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,12 +22,12 @@ then
 elif [ -n "${DBT_USER}" ] && [ -n "$DBT_PASSWORD" ]
 then
  echo trying to use user/password
- sed -i "s/_user_/${DBT_USER}/g" ./datab.yml
+ sed -i "s/_user_/${DBT_USER}/g" ./profiles.yml
  sed -i "s/_password_/${DBT_PASSWORD}/g" ./profiles.yml
 elif [ -n "${DBT_TOKEN}" ]
 then
  echo trying to use DBT_TOKEN/databricks
- sed -i "s/_token_/${DBT_TOKEN}/g" ./profiles.yml
+ sed -i "s/_token_/${DBT_TOKEN}/g" ./datab.yml
 else
   echo no tokens or credentials supplied
 fi


### PR DESCRIPTION
I guess `profiles.yml` is the standard dbt config file, but `datab.yml` is for Databricks.
Thanks for your github action.