### PR TITLE
allow for upgrading deps in libsasl2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DBT_VERSION=1.0.0
 FROM fishtownanalytics/dbt:${DBT_VERSION}
-RUN apt-get update && apt-get install libsasl2-dev
+RUN apt-get update && apt-get install libsasl2-dev -y
 
 # Need to re-declare the ARG to use its default value defined before the FROM
 ARG DBT_VERSION


### PR DESCRIPTION
Resolves: #21 

Allow for upgrading dependencies.

`The following packages will be upgraded:
libsasl2-2 libsasl2-modules-db
2 upgraded, 1 newly installed, 0 to remove and 14 not upgraded.
Need to get 456 kB of archives.
After this operation, 925 kB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.`