### PR TITLE
Set command

### DIFF
--- a/Docker_build/Dockerfile
+++ b/Docker_build/Dockerfile
@@ -14,12 +14,12 @@ FROM --platform=$build_for python:3.9.9-slim-bullseye as base
 # N.B. The refs updated automagically every release via bumpversion
 # N.B. dbt-postgres is currently found in the core codebase so a value of dbt-core@<some_version> is correct
 
-ARG dbt_core_ref=dbt-core@v1.3.0
-ARG dbt_postgres_ref=dbt-core@v1.3.0
-ARG dbt_redshift_ref=dbt-redshift@v1.3.0
-ARG dbt_bigquery_ref=dbt-bigquery@v1.3.0
-ARG dbt_snowflake_ref=dbt-snowflake@v1.3.0
-ARG dbt_spark_ref=dbt-spark@v1.3.0
+ARG dbt_core_ref=dbt-core@v1.4.6
+ARG dbt_postgres_ref=dbt-core@v1.4.6
+ARG dbt_redshift_ref=dbt-redshift@v1.4.0
+ARG dbt_bigquery_ref=dbt-bigquery@v1.4.3
+ARG dbt_snowflake_ref=dbt-snowflake@v1.4.2
+ARG dbt_spark_ref=dbt-spark@v1.4.1
 # special case args
 ARG dbt_spark_version=all
 ARG dbt_third_party

--- a/Docker_build/README.md
+++ b/Docker_build/README.md
@@ -1,0 +1,7 @@
+# how to build the Docker image and send to Docker Hub
+
+update the references in the Dockerfile to current ones.
+
+`docker build --tag mwhitaker/dbt_all:v1.4.6  --target dbt-all .`
+
+`docker push mwhitaker/dbt_all:v1.4.6`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DBT_VERSION=v1.3.0
+ARG DBT_VERSION=v1.4.6
 FROM mwhitaker/dbt_all:${DBT_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A GitHub Action to run [dbt](https://www.getdbt.com) commands in a Docker container. It uses the official images provided by [Fishtown Analytics](https://hub.docker.com/r/fishtownanalytics/dbt/tags). You can use [dbt commands](https://docs.getdbt.com/reference/dbt-commands) such as `run`, `test` and `debug`. This action captures the dbt console output for use in subsequent steps.
 
 ### dbt version
-The current version of dbt is **1.3.0**. Please note that from dbt v1.0.0. you may have to change your dbt project structure compared to v0.x.x. See the [migration](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0) docs.
+The current version of dbt is **1.4.6**. Please note that from dbt v1.0.0. you may have to change your dbt project structure compared to v0.x.x. See the [migration](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0) docs.
 
 dbt updates their [docker images](https://hub.docker.com/r/fishtownanalytics/dbt/tags?page=1&ordering=last_updated) on a frequent basis and the main branch of this Github Action should be close to the last stable tag. If you need to use an earlier version of dbt, you can call this action with a specific [release](https://github.com/mwhitaker/dbt-action/releases), eg `mwhitaker/dbt-action@v0.21.0` or `mwhitaker/dbt-action@v0.19.1`.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,11 +40,11 @@ $1 2>&1 | tee "${DBT_ACTION_LOG_FILE}"
 if [ $? -eq 0 ]
   then
     echo "DBT_RUN_STATE=passed" >> $GITHUB_ENV
-    echo "::set-output name=result::passed"
+    echo "result=passed" >> $GITHUB_OUTPUT
     echo "DBT run OK" >> "${DBT_ACTION_LOG_FILE}"
   else
     echo "DBT_RUN_STATE=failed" >> $GITHUB_ENV
-    echo "::set-output name=result::failed"
+    echo "result=failed" >> $GITHUB_OUTPUT
     echo "DBT run failed" >> "${DBT_ACTION_LOG_FILE}"
     exit 1
 fi


### PR DESCRIPTION
This updates the [set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) commands that have been deprecated 